### PR TITLE
Login Callback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
+        "barryvdh/laravel-ide-helper": "^2.13",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.9",
         "nunomaduro/larastan": "^2.0.1",

--- a/src/Controllers/SocialmentController.php
+++ b/src/Controllers/SocialmentController.php
@@ -3,6 +3,8 @@
 namespace ChrisReedIO\Socialment\Controllers;
 
 use ChrisReedIO\Socialment\Models\ConnectedAccount;
+use ChrisReedIO\Socialment\Facades\Socialment;
+use ChrisReedIO\Socialment\SocialmentPlugin;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller;
@@ -59,6 +61,10 @@ class SocialmentController extends Controller
         }
 
         auth()->login($connectedAccount->user);
+
+		/** @var SocialmentPlugin $plugin */
+		$plugin = Socialment::getFacadeRoot();
+        $plugin->executePostLogin($connectedAccount);
 
         return redirect()->route(config('socialment.routes.home'));
     }

--- a/src/Controllers/SocialmentController.php
+++ b/src/Controllers/SocialmentController.php
@@ -2,8 +2,8 @@
 
 namespace ChrisReedIO\Socialment\Controllers;
 
-use ChrisReedIO\Socialment\Models\ConnectedAccount;
 use ChrisReedIO\Socialment\Facades\Socialment;
+use ChrisReedIO\Socialment\Models\ConnectedAccount;
 use ChrisReedIO\Socialment\SocialmentPlugin;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -62,8 +62,8 @@ class SocialmentController extends Controller
 
         auth()->login($connectedAccount->user);
 
-		/** @var SocialmentPlugin $plugin */
-		$plugin = Socialment::getFacadeRoot();
+        /** @var SocialmentPlugin $plugin */
+        $plugin = Socialment::getFacadeRoot();
         $plugin->executePostLogin($connectedAccount);
 
         return redirect()->route(config('socialment.routes.home'));

--- a/src/Facades/Socialment.php
+++ b/src/Facades/Socialment.php
@@ -11,6 +11,6 @@ class Socialment extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \ChrisReedIO\Socialment\Socialment::class;
+        return \ChrisReedIO\Socialment\SocialmentPlugin::class;
     }
 }

--- a/src/SocialmentPlugin.php
+++ b/src/SocialmentPlugin.php
@@ -2,6 +2,7 @@
 
 namespace ChrisReedIO\Socialment;
 
+use ChrisReedIO\Socialment\Models\ConnectedAccount;
 use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
@@ -13,6 +14,8 @@ class SocialmentPlugin implements Plugin
     use EvaluatesClosures;
 
     public bool | Closure | null $visible = null;
+
+	public ?Closure $loginCallback = null;
 
     public function getId(): string
     {
@@ -70,4 +73,30 @@ class SocialmentPlugin implements Plugin
 
         return $this;
     }
+
+	/**
+	 * Sets up a callback to be called after a user logs in.
+	 * @param Closure $callback 
+	 * @return static 
+	 */
+	public function postLogin(Closure $callback): static
+	{
+		// config()->set('socialment.post_login', $callback);
+		$this->loginCallback = $callback;
+
+		return $this;
+	}
+
+	/**
+	 * Executes the post login callback. Set up closure to execute via the postLogin method.
+	 * @param ConnectedAccount $account 
+	 * @return void 
+	 */
+	public function executePostLogin(ConnectedAccount $account): void
+	{
+		if ($callback = $this->loginCallback) {
+			($callback)($account);
+		}
+	}
 }
+

--- a/src/SocialmentPlugin.php
+++ b/src/SocialmentPlugin.php
@@ -15,7 +15,7 @@ class SocialmentPlugin implements Plugin
 
     public bool | Closure | null $visible = null;
 
-	public ?Closure $loginCallback = null;
+    public ?Closure $loginCallback = null;
 
     public function getId(): string
     {
@@ -74,29 +74,24 @@ class SocialmentPlugin implements Plugin
         return $this;
     }
 
-	/**
-	 * Sets up a callback to be called after a user logs in.
-	 * @param Closure $callback 
-	 * @return static 
-	 */
-	public function postLogin(Closure $callback): static
-	{
-		// config()->set('socialment.post_login', $callback);
-		$this->loginCallback = $callback;
+    /**
+     * Sets up a callback to be called after a user logs in.
+     */
+    public function postLogin(Closure $callback): static
+    {
+        // config()->set('socialment.post_login', $callback);
+        $this->loginCallback = $callback;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	/**
-	 * Executes the post login callback. Set up closure to execute via the postLogin method.
-	 * @param ConnectedAccount $account 
-	 * @return void 
-	 */
-	public function executePostLogin(ConnectedAccount $account): void
-	{
-		if ($callback = $this->loginCallback) {
-			($callback)($account);
-		}
-	}
+    /**
+     * Executes the post login callback. Set up closure to execute via the postLogin method.
+     */
+    public function executePostLogin(ConnectedAccount $account): void
+    {
+        if ($callback = $this->loginCallback) {
+            ($callback)($account);
+        }
+    }
 }
-


### PR DESCRIPTION
Adds a login callback.

This must be configured in a service provider's boot method as the panel configuration isn't loaded on the redirect handler's routes.

See the new section of the readme, `Post Login Callback`, for more information. 