### PR TITLE
Migration to allow nullable passwords for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,36 +50,29 @@ composer require chrisreedio/socialment
 
 #### Initial Setup
 
-After installation you should publish and run the migration(s) with:
-
-> [!IMPORTANT]  
-> This package requires that the `users` `password` field be nullable.
->
-> If you have not already done so, you should update your `users` table migration to make this change.
+You can easily perform the initial setup by running the following command:
 
 ```bash
-php artisan vendor:publish --tag="socialment-migrations"
-php artisan migrate
+php artisan socialment:install
 ```
 
-Then publish the config file with:
-
-```bash
-php artisan vendor:publish --tag="socialment-config"
-```
-
-Finally, edit your panel's `tailwind.config.js` content section to include the following:
+Additionally, edit your panel's `tailwind.config.js` content section to include the last line of the following:
 
 ```js
     content: [
         "./app/Filament/**/*.php",
         "./resources/views/filament/**/*.blade.php",
         "./vendor/filament/**/*.blade.php",
+        // ... Other Content Paths
 
-		// Ensure the line below is listed
+		// Ensure the line below is listed!!!
         "./vendor/chrisreedio/socialment/resources/**/*.blade.php",
     ],
 ```
+
+If this step is forgotten, the styling of the plugin will not be applied.
+
+Please continue to the next sections to continue the setup process.
 
 #### Provider Configuration
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ If this step is forgotten, the styling of the plugin will not be applied.
 
 Please continue to the next sections to continue the setup process.
 
+### Panel Configuration
+
+Include this plugin in your panel configuration:
+
+```php
+$panel
+	->plugins([
+		// ... Other Plugins
+		\ChrisReedIO\Socialment\SocialmentPlugin::make(),
+	])
+```
+
 #### Provider Configuration
 
 > [!IMPORTANT]
@@ -168,18 +180,6 @@ The `usage` section can usually be ignored as that is the main part this package
 This package also uses the [Blade Font Awesome package](https://github.com/owenvoke/blade-fontawesome) by [Owen Voke](https://github.com/owenvoke). 
 
 Search for brand icons on the [Font Awesome Website](https://fontawesome.com/search?o=r&f=brands).
-
-### Panel Configuration
-
-Include this plugin in your panel configuration:
-
-```php
-$panel
-	->plugins([
-		// ... Other Plugins
-		\ChrisReedIO\Socialment\SocialmentPlugin::make(),
-	])
-```
 
 
 ### Visibility Override

--- a/database/migrations/modify_users_table_nullable_password.php.stub
+++ b/database/migrations/modify_users_table_nullable_password.php.stub
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+	public function up()
+	{
+		if (Schema::hasTable('users')) {
+			Schema::table('users', function (Blueprint $table) {
+				$table->string('password')->nullable()->change();
+			});
+		}
+	}
+};

--- a/src/SocialmentServiceProvider.php
+++ b/src/SocialmentServiceProvider.php
@@ -147,6 +147,7 @@ class SocialmentServiceProvider extends PackageServiceProvider
     {
         return [
             'create_connected_accounts_table',
+            'modify_users_table_nullable_password',
         ];
     }
 }


### PR DESCRIPTION
This PR adds a migration that modifies the user's password field to allow nullable passwords. 

This prevents the developer user from having to edit their initial user migration or create a new one on their own.