### PR TITLE
✨ feat: Added support for custom scopes in social providers

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,10 +20,10 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
-            testbench: 8.*
+            testbench: ^8.14
             carbon: ^2.63
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ^9.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
             testbench: ^8.14
             carbon: ^2.63
           - laravel: 11.*
-            testbench: ^9.*
+            testbench: 9.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/src/Http/Controllers/SocialmentController.php
+++ b/src/Http/Controllers/SocialmentController.php
@@ -141,7 +141,7 @@ class SocialmentController extends BaseController
 
             return redirect()->to($intendedUrl);
         } catch (Exception $e) {
-            Session::flash('socialment.error', 'An unknown error occurred: '.$e->getMessage().'. Please try again.');
+            Session::flash('socialment.error', 'An unknown error occurred: ' . $e->getMessage() . '. Please try again.');
 
             return redirect()->to($intendedUrl);
         }

--- a/src/SocialmentPlugin.php
+++ b/src/SocialmentPlugin.php
@@ -50,6 +50,11 @@ class SocialmentPlugin implements Plugin
         return array_merge(config('socialment.providers'), $this->providers);
     }
 
+    public function getProvider(string $provider): array
+    {
+        return $this->getProviders()[$provider];
+    }
+
     public function register(Panel $panel): void
     {
         $panel->renderHook('panels::auth.login.form.before', function () {
@@ -217,11 +222,12 @@ class SocialmentPlugin implements Plugin
         }
     }
 
-    public function registerProvider(string $provider, string $icon, string $label): static
+    public function registerProvider(string $provider, string $icon, string $label, array $scopes = []): static
     {
         $this->providers[$provider] = [
             'icon' => $icon,
             'label' => $label,
+            'scopes' => $scopes,
         ];
 
         return $this;

--- a/src/SocialmentServiceProvider.php
+++ b/src/SocialmentServiceProvider.php
@@ -58,7 +58,7 @@ class SocialmentServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        //
+        $this->app->singleton(SocialmentPlugin::class, fn () => new SocialmentPlugin());
     }
 
     public function packageBooted(): void


### PR DESCRIPTION
Can now add 'scopes' to a provider at registration time in the panel provider.

GitHub Example:

```php
->registerProvider('github', 'fab-github', 'Github', [
    'read:user',
    'repo',
]),
```

TODO: Update the README to include the functionality after it passes some smoke testing.