### PR TITLE
remove the exception message, and use report

### DIFF
--- a/src/Http/Controllers/SocialmentController.php
+++ b/src/Http/Controllers/SocialmentController.php
@@ -115,12 +115,16 @@ class SocialmentController extends BaseController
 
             Socialment::executePostLogin($connectedAccount);
         } catch (InvalidStateException $e) {
+            report($e);
             Session::flash('socialment.error', 'Something went wrong. Please try again.');
         } catch (\GuzzleHttp\Exception\ClientException $e) {
+            report($e);
             Session::flash('socialment.error', 'We had a problem contacting the authentication server. Please try again.');
         } catch (AbortedLoginException $e) {
-            Session::flash('socialment.error', $e->getMessage());
+            report($e);
+            Session::flash('socialment.error', 'Login aborted');
         } catch (Exception $e) {
+            report($e);
             Session::flash('socialment.error', 'An unknown error occurred: ' . $e->getMessage() . '. Please try again.');
         }
 


### PR DESCRIPTION
hey Chris, so I got [this error](https://discord.com/channels/883083792112300104/956270111176679516/1293676226040434708) as you can see the message contain kinda sensitive info about the database when the expiation `AbortedLoginException` thrown.
so I replaced that with `Login aborted` instead of `$e->getMessage()`

the other thing that I didn't get an exception alert on sentry (or any other error reporting tools) coz the exception been handled by (try/catch), so I added `report($e);`.