### PR TITLE
fix: return 404 for unregistered providers instead of 500

### DIFF
--- a/src/Http/Controllers/SocialmentController.php
+++ b/src/Http/Controllers/SocialmentController.php
@@ -53,14 +53,33 @@ class SocialmentController extends BaseController
 
     private function getProviderRedirect(string $providerName): \Illuminate\Http\RedirectResponse
     {
+        $providerConfig = $this->getProviderConfig($providerName);
+
         /** @var AbstractProvider $provider */
         $provider = Socialite::driver($providerName);
-        $providerConfig = App::make(SocialmentPlugin::class)->getProvider($providerName);
         if (! empty($providerConfig['scopes'])) {
             $provider->scopes($providerConfig['scopes']);
         }
 
         return $provider->redirect();
+    }
+
+    /**
+     * Resolve the configuration for a registered provider.
+     *
+     * Unknown providers (e.g. someone hitting /login/foo) are a missing
+     * resource, not a server error, so abort with a 404 instead of letting
+     * Socialite throw and surface as a 500.
+     *
+     * @return array<string, mixed>
+     */
+    private function getProviderConfig(string $providerName): array
+    {
+        $providers = App::make(SocialmentPlugin::class)->getProviders();
+
+        abort_unless(array_key_exists($providerName, $providers), 404);
+
+        return $providers[$providerName];
     }
 
     public function callback(string $provider): RedirectResponse

--- a/tests/UnknownProviderTest.php
+++ b/tests/UnknownProviderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    config()->set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+});
+
+it('returns 404 when redirecting to an unregistered provider', function () {
+    get(route('socialment.redirect', ['provider' => 'unknown']))
+        ->assertNotFound();
+});
+
+it('returns 404 on the panel redirect for an unregistered provider', function () {
+    get(route('socialment.redirect.panel', ['provider' => 'unknown', 'panelId' => 'admin']))
+        ->assertNotFound();
+});


### PR DESCRIPTION
## Problem

Hitting `/login/{provider}` with a provider that isn't registered (e.g. `/login/foo`, or a bot/scanner probing random paths) throws an uncaught `InvalidArgumentException: Driver [foo] not supported.` from `Socialite::driver()`, which surfaces as a **500 Internal Server Error** and pollutes error tracking.

An unknown provider is a *missing resource*, not a server error — it should be a **404**.

```
InvalidArgumentException: Driver [foo] not supported.
  at SocialmentController::getProviderRedirect()
```

## Fix

Validate the provider against the plugin's registered providers before resolving the Socialite driver, and `abort(404)` when it isn't registered. This also avoids the latent undefined-array-key access in the (now unused) `SocialmentPlugin::getProvider()` for unknown keys, and doesn't rely on Socialite's internal exception type/message.

The check is scoped to the redirect routes (`socialment.redirect`, `socialment.redirect.panel`). The `callback()` flow is intentionally left unchanged: it already swallows unknown-provider errors via its generic `catch` and never 500s.

## Tests

Added `tests/UnknownProviderTest.php` covering 404 on both the single-panel and multi-panel redirect routes. Full suite + PHPStan + Pint pass.